### PR TITLE
[DDE-5] Model Matrix Implementation for Drawable Class

### DIFF
--- a/glsl/primitive/primitive.vert
+++ b/glsl/primitive/primitive.vert
@@ -7,8 +7,10 @@ layout(location = 2) in vec4 dde_texture;
 out vec4 vert_color;
 out vec4 vert_texture;
 
+uniform mat4 dde_model_matrix;
+
 void main() {
   vert_color = dde_color;
   vert_texture = dde_texture;
-  gl_Position = vec4(dde_position);
+  gl_Position = dde_model_matrix * dde_position;
 }

--- a/include/DDE/Engine/ShaderEngine.hpp
+++ b/include/DDE/Engine/ShaderEngine.hpp
@@ -20,6 +20,8 @@ public:
   static DDE::ShaderStore shaderStore;
 
   static void ActivateShaderStage(DDE::ShaderStage stage);
+  static void UpdateModelMatrix(glm::mat4 matrix);
+
   ShaderEngine() = delete;
 };
 

--- a/include/DDE/Graphics/Drawable.hpp
+++ b/include/DDE/Graphics/Drawable.hpp
@@ -24,6 +24,12 @@ protected:
   // The model matrix for this drawable object.
   glm::mat4 _modelMatrix;
 
+  // TODO: Documentation
+  DDE::Vec4 _position;
+
+  // TODO: Documentation
+  DDE::Vec4 _size;
+
   virtual void _initializeGLObjects() = 0;
   virtual void _setUpVertexData(DDE::VertexBuffer &vbo) = 0;
 
@@ -34,6 +40,8 @@ protected:
 public:
   glm::mat4 getModelMatrix() const;
   DDE::ShaderStage getShaderPipeline() const;
+  DDE::Vec4 getPosition() const;
+  DDE::Vec4 getSize() const;
 
   void translate(glm::vec3 directionVector);
   void rotate(float degrees, glm::vec3 rotationVector);

--- a/include/DDE/Graphics/Drawable.hpp
+++ b/include/DDE/Graphics/Drawable.hpp
@@ -27,7 +27,7 @@ protected:
   // The current position of this drawable object.
   glm::vec3 _position;
 
-  // The current size of this drawable object.
+  // The current scale of this drawable object on each axis.
   glm::vec3 _scale;
 
   virtual void _initializeGLObjects() = 0;

--- a/include/DDE/Graphics/Drawable.hpp
+++ b/include/DDE/Graphics/Drawable.hpp
@@ -24,11 +24,11 @@ protected:
   // The model matrix for this drawable object.
   glm::mat4 _modelMatrix;
 
-  // TODO: Documentation
-  DDE::Vec4 _position;
+  // The current position of this drawable object.
+  glm::vec3 _position;
 
-  // TODO: Documentation
-  DDE::Vec4 _size;
+  // The current size of this drawable object.
+  glm::vec3 _scale;
 
   virtual void _initializeGLObjects() = 0;
   virtual void _setUpVertexData(DDE::VertexBuffer &vbo) = 0;
@@ -40,8 +40,8 @@ protected:
 public:
   glm::mat4 getModelMatrix() const;
   DDE::ShaderStage getShaderPipeline() const;
-  DDE::Vec4 getPosition() const;
-  DDE::Vec4 getSize() const;
+  glm::vec3 getPosition() const;
+  glm::vec3 getScale() const;
 
   void translate(glm::vec3 directionVector);
   void rotate(float degrees, glm::vec3 rotationVector);

--- a/include/DDE/Graphics/Drawable.hpp
+++ b/include/DDE/Graphics/Drawable.hpp
@@ -3,6 +3,7 @@
 #include <DDE/Graphics/Buffer/VertexBuffer.hpp>
 #include <DDE/Graphics/Vertex/Vec4.hpp>
 #include <DDE/Utility/ShaderTypes.hpp>
+#include <glm/glm.hpp>
 
 namespace DDE {
 
@@ -20,6 +21,8 @@ protected:
   DDE::ShaderStage _shaderPipelineID;
   // The color of the drawable object.
   DDE::Vec4 _color;
+  // The model matrix for this drawable object.
+  glm::mat4 _modelMatrix;
 
   virtual void _initializeGLObjects() = 0;
   virtual void _setUpVertexData(DDE::VertexBuffer &vbo) = 0;
@@ -29,7 +32,13 @@ protected:
            DDE::Vec4 color = DDE::Vec4{1.0f, 1.0f, 1.0f, 1.0f});
 
 public:
+  glm::mat4 getModelMatrix() const;
   DDE::ShaderStage getShaderPipeline() const;
+
+  void translate(glm::vec3 directionVector);
+  void rotate(float degrees, glm::vec3 rotationVector);
+  void scale(glm::vec3 scaleVector);
+
   ~Drawable() = default;
   virtual void render() = 0;
 };

--- a/include/DDE/Graphics/Pencil/Pencil.hpp
+++ b/include/DDE/Graphics/Pencil/Pencil.hpp
@@ -47,7 +47,7 @@ public:
       config->preDraw();
     }
 
-    // TODO: Documentation
+    // Update the Model Matrix to the drawable object's model matrix
     DDE::ShaderEngine::UpdateModelMatrix(drawableObject.getModelMatrix());
     // Render the drawable object
     drawableObject.render();

--- a/include/DDE/Graphics/Pencil/Pencil.hpp
+++ b/include/DDE/Graphics/Pencil/Pencil.hpp
@@ -46,6 +46,9 @@ public:
     for (const std::unique_ptr<DDE::DrawConfig> &config : configs) {
       config->preDraw();
     }
+
+    // TODO: Documentation
+    DDE::ShaderEngine::UpdateModelMatrix(drawableObject.getModelMatrix());
     // Render the drawable object
     drawableObject.render();
 

--- a/include/DDE/Graphics/Shader/ShaderStore.hpp
+++ b/include/DDE/Graphics/Shader/ShaderStore.hpp
@@ -36,6 +36,7 @@ public:
 
   unsigned int loadShaderPipeline(DDE::ShaderStage stage);
   DDE::ShaderStage getActiveShaderStage() const;
+  DDE::ShaderProgram getActiveShaderProgram() const;
 };
 
 } // namespace DDE

--- a/include/DDE/Utility/PositionTypes.hpp
+++ b/include/DDE/Utility/PositionTypes.hpp
@@ -1,5 +1,7 @@
 #include <glm/vec3.hpp>
+
 namespace DDE {
+// These are the base axis' vector representations in space (X, Y, Z)
 inline constexpr glm::vec3 X_AXIS_VECTOR = glm::vec3(1.0f, 0.0f, 0.0f);
 inline constexpr glm::vec3 Y_AXIS_VECTOR = glm::vec3(0.0f, 1.0f, 0.0f);
 inline constexpr glm::vec3 Z_AXIS_VECTOR = glm::vec3(0.0f, 0.0f, 1.0f);

--- a/include/DDE/Utility/PositionTypes.hpp
+++ b/include/DDE/Utility/PositionTypes.hpp
@@ -1,0 +1,6 @@
+#include <glm/vec3.hpp>
+namespace DDE {
+inline constexpr glm::vec3 X_AXIS_VECTOR = glm::vec3(1.0f, 0.0f, 0.0f);
+inline constexpr glm::vec3 Y_AXIS_VECTOR = glm::vec3(0.0f, 1.0f, 0.0f);
+inline constexpr glm::vec3 Z_AXIS_VECTOR = glm::vec3(0.0f, 0.0f, 1.0f);
+}; // namespace DDE

--- a/include/DDE/Utility/ShaderTypes.hpp
+++ b/include/DDE/Utility/ShaderTypes.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
+#include <string>
 namespace DDE {
 
 // This enum is used to represent Shader Stages
 enum ShaderStage { NONE = -1, PRIMITIVE = 0, SCENE = 1, OBJECT = 2 };
 
-}  // namespace DDE
+/* This struct holds the DDE specific uniform variables that will be found in
+   its shader source code */
+struct ShaderUniform {
+  inline static const std::string MODEL_MATRIX = "dde_model_matrix";
+};
+
+} // namespace DDE

--- a/src/Engine/ShaderEngine.cpp
+++ b/src/Engine/ShaderEngine.cpp
@@ -1,3 +1,4 @@
+#include "DDE/Utility/ShaderTypes.hpp"
 #include <DDE/Engine/ShaderEngine.hpp>
 #include <glm/fwd.hpp>
 
@@ -17,10 +18,20 @@ void DDE::ShaderEngine::ActivateShaderStage(DDE::ShaderStage stage) {
   }
 }
 
-// TODO: Documentation
+/**
+ * This function is used by the ShaderEngine to update the
+ * active model matrix in the active DDE Shader to ensure that
+ * the object that is about to be drawn is accurate to what it's
+ * model matrix is.
+ *
+ * @param matrix The matrix to update the 'dde_model_matrix' uniform
+ *               variable to.
+ */
 void DDE::ShaderEngine::UpdateModelMatrix(glm::mat4 matrix) {
+  // Get the active ShaderProgram object from our singleton ShaderStore
   DDE::ShaderProgram activeProgram =
       ShaderEngine::shaderStore.getActiveShaderProgram();
-  // TODO: Put 'dde_model_matrix' into an enum
-  activeProgram.setMatrix4x4Uniform("dde_model_matrix", matrix);
+
+  // Set our 'dde_model_matrix' uniform variable to the matrix passed
+  activeProgram.setMatrix4x4Uniform(DDE::ShaderUniform::MODEL_MATRIX, matrix);
 }

--- a/src/Engine/ShaderEngine.cpp
+++ b/src/Engine/ShaderEngine.cpp
@@ -1,4 +1,5 @@
 #include <DDE/Engine/ShaderEngine.hpp>
+#include <glm/fwd.hpp>
 
 // Define the static member variable shaderStore to a default DDE::ShaderStore
 DDE::ShaderStore DDE::ShaderEngine::shaderStore;
@@ -14,4 +15,12 @@ void DDE::ShaderEngine::ActivateShaderStage(DDE::ShaderStage stage) {
   if (ShaderEngine::shaderStore.getActiveShaderStage() != stage) {
     glUseProgram(ShaderEngine::shaderStore.loadShaderPipeline(stage));
   }
+}
+
+// TODO: Documentation
+void DDE::ShaderEngine::UpdateModelMatrix(glm::mat4 matrix) {
+  DDE::ShaderProgram activeProgram =
+      ShaderEngine::shaderStore.getActiveShaderProgram();
+  // TODO: Put 'dde_model_matrix' into an enum
+  activeProgram.setMatrix4x4Uniform("dde_model_matrix", matrix);
 }

--- a/src/Engine/ShaderEngine.cpp
+++ b/src/Engine/ShaderEngine.cpp
@@ -1,5 +1,5 @@
-#include "DDE/Utility/ShaderTypes.hpp"
 #include <DDE/Engine/ShaderEngine.hpp>
+#include <DDE/Utility/ShaderTypes.hpp>
 #include <glm/fwd.hpp>
 
 // Define the static member variable shaderStore to a default DDE::ShaderStore

--- a/src/Graphics/Drawable.cpp
+++ b/src/Graphics/Drawable.cpp
@@ -12,9 +12,8 @@
  * @param color The RGBA of this drawable object
  */
 DDE::Drawable::Drawable(DDE::ShaderStage shaderPipeline, DDE::Vec4 color)
-    : _shaderPipelineID(shaderPipeline), _color(color),
-      _modelMatrix(glm::mat4(1.0f)), _position{0, 0, 0, 0},
-      _size{1.0, 1.0, 1.0, 1.0} {}
+    : _shaderPipelineID(shaderPipeline), _color(color), _modelMatrix{1.0f},
+      _position{0.0f}, _scale{1.0f} {}
 
 /**
  * This is our function to get the shader pipeline ID from
@@ -24,36 +23,64 @@ DDE::ShaderStage DDE::Drawable::getShaderPipeline() const {
   return this->_shaderPipelineID;
 }
 
-// TODO:Documentation
+/**
+ * Getter for the model matrix of a drawable object.
+ *
+ * @returns The model matrix of this drawable object
+ */
 glm::mat4 DDE::Drawable::getModelMatrix() const { return this->_modelMatrix; }
 
-// TODO: Documentation
-DDE::Vec4 DDE::Drawable::getPosition() const { return this->_position; }
+/**
+ * Getter for the current position of a drawable object.
+ *
+ * @returns The current position of a drawable object as a vec3
+ */
+glm::vec3 DDE::Drawable::getPosition() const { return this->_position; }
 
-// TODO: Documentation
-DDE::Vec4 DDE::Drawable::getSize() const { return this->_size; }
+/**
+ * Getter for the current scaling of a drawable object on each axis.
+ *
+ * @returns The current scaling for each axis of the drawable object as a vec3
+ */
+glm::vec3 DDE::Drawable::getScale() const { return this->_scale; }
 
-// TODO: Documentation
-void DDE::Drawable::translate(glm::vec3 directionVector) {
-  // TODO: Documentation/Change how we do this
-  this->_position.x += directionVector.x;
-  this->_position.y += directionVector.y;
-  this->_position.z += directionVector.z;
+/**
+ * This function is utilized to translate a drawable object in space.
+ *
+ * @param translationVector The (x, y, z) coordinate direction to translate.
+ *                          The magnitude is included in this vector, it does
+ *                          not have to be a unit vector.
+ */
+void DDE::Drawable::translate(glm::vec3 translationVector) {
+  // Add the translation vector to our position vector of this object
+  this->_position += translationVector;
 
-  this->_modelMatrix = glm::translate(this->_modelMatrix, directionVector);
+  // Translate the model matrix for the object
+  this->_modelMatrix = glm::translate(this->_modelMatrix, translationVector);
 }
 
-// TODO: Documentation
+/**
+ * This function is utilized to rotate a drawable object on a specific axis.
+ *
+ * @param degrees The amount to rotate the object in degrees
+ * @param rotationVector The axis to rotate the object on
+ */
 void DDE::Drawable::rotate(float degrees, glm::vec3 rotationVector) {
+  // Rotate the model matrix for the object
   this->_modelMatrix = glm::rotate(this->_modelMatrix, degrees, rotationVector);
 }
 
-// TODO: Documentation
+/**
+ * This function is utilized to scale the drawable object in some way on
+ * each of it's axis'.
+ *
+ * @param scaleVector The scale factor for each (x, y, z) component of the
+ *                    object
+ */
 void DDE::Drawable::scale(glm::vec3 scaleVector) {
-  // TODO: Documentation/Change how we do this
-  this->_size.x *= scaleVector.x;
-  this->_size.y *= scaleVector.y;
-  this->_size.z *= scaleVector.z;
+  // Multiply each scale component by the passed scale vector components.
+  this->_scale *= scaleVector;
 
+  // Scale the model matrix for the object
   this->_modelMatrix = glm::scale(this->_modelMatrix, scaleVector);
 }

--- a/src/Graphics/Drawable.cpp
+++ b/src/Graphics/Drawable.cpp
@@ -1,3 +1,4 @@
+#include "glm/ext/matrix_transform.hpp"
 #include <DDE/Graphics/Drawable.hpp>
 
 /**
@@ -10,7 +11,8 @@
  * @param color The RGBA of this drawable object
  */
 DDE::Drawable::Drawable(DDE::ShaderStage shaderPipeline, DDE::Vec4 color)
-    : _shaderPipelineID(shaderPipeline), _color(color) {}
+    : _shaderPipelineID(shaderPipeline), _color(color),
+      _modelMatrix(glm::mat4(1.0f)) {}
 
 /**
  * This is our function to get the shader pipeline ID from
@@ -18,4 +20,22 @@ DDE::Drawable::Drawable(DDE::ShaderStage shaderPipeline, DDE::Vec4 color)
  */
 DDE::ShaderStage DDE::Drawable::getShaderPipeline() const {
   return this->_shaderPipelineID;
+}
+
+// TODO:Documentation
+glm::mat4 DDE::Drawable::getModelMatrix() const { return this->_modelMatrix; }
+
+// TODO: Documentation
+void DDE::Drawable::translate(glm::vec3 directionVector) {
+  this->_modelMatrix = glm::translate(this->_modelMatrix, directionVector);
+}
+
+// TODO: Documentation
+void DDE::Drawable::rotate(float degrees, glm::vec3 rotationVector) {
+  this->_modelMatrix = glm::rotate(this->_modelMatrix, degrees, rotationVector);
+}
+
+// TODO: Documentation
+void DDE::Drawable::scale(glm::vec3 scaleVector) {
+  this->_modelMatrix = glm::scale(this->_modelMatrix, scaleVector);
 }

--- a/src/Graphics/Drawable.cpp
+++ b/src/Graphics/Drawable.cpp
@@ -1,5 +1,6 @@
-#include "glm/ext/matrix_transform.hpp"
 #include <DDE/Graphics/Drawable.hpp>
+#include <DDE/Graphics/Vertex/Vec4.hpp>
+#include <glm/ext/matrix_transform.hpp>
 
 /**
  * The constructor is simply used to specify the shader pipeline
@@ -12,7 +13,8 @@
  */
 DDE::Drawable::Drawable(DDE::ShaderStage shaderPipeline, DDE::Vec4 color)
     : _shaderPipelineID(shaderPipeline), _color(color),
-      _modelMatrix(glm::mat4(1.0f)) {}
+      _modelMatrix(glm::mat4(1.0f)), _position{0, 0, 0, 0},
+      _size{1.0, 1.0, 1.0, 1.0} {}
 
 /**
  * This is our function to get the shader pipeline ID from
@@ -26,7 +28,18 @@ DDE::ShaderStage DDE::Drawable::getShaderPipeline() const {
 glm::mat4 DDE::Drawable::getModelMatrix() const { return this->_modelMatrix; }
 
 // TODO: Documentation
+DDE::Vec4 DDE::Drawable::getPosition() const { return this->_position; }
+
+// TODO: Documentation
+DDE::Vec4 DDE::Drawable::getSize() const { return this->_size; }
+
+// TODO: Documentation
 void DDE::Drawable::translate(glm::vec3 directionVector) {
+  // TODO: Documentation/Change how we do this
+  this->_position.x += directionVector.x;
+  this->_position.y += directionVector.y;
+  this->_position.z += directionVector.z;
+
   this->_modelMatrix = glm::translate(this->_modelMatrix, directionVector);
 }
 
@@ -37,5 +50,10 @@ void DDE::Drawable::rotate(float degrees, glm::vec3 rotationVector) {
 
 // TODO: Documentation
 void DDE::Drawable::scale(glm::vec3 scaleVector) {
+  // TODO: Documentation/Change how we do this
+  this->_size.x *= scaleVector.x;
+  this->_size.y *= scaleVector.y;
+  this->_size.z *= scaleVector.z;
+
   this->_modelMatrix = glm::scale(this->_modelMatrix, scaleVector);
 }

--- a/src/Graphics/Shader/ShaderStore.cpp
+++ b/src/Graphics/Shader/ShaderStore.cpp
@@ -1,3 +1,4 @@
+#include "DDE/Graphics/Shader/ShaderProgram.hpp"
 #include <Glad/glad/glad.h>
 
 #include <DDE/Graphics/Shader/ShaderStore.hpp>
@@ -70,4 +71,9 @@ void DDE::ShaderStore::_cacheShaderPipeline(DDE::ShaderStage stage) {
  */
 DDE::ShaderStage DDE::ShaderStore::getActiveShaderStage() const {
   return this->_currentActiveStage;
+}
+
+// TODO: Documentation
+DDE::ShaderProgram DDE::ShaderStore::getActiveShaderProgram() const {
+  return this->_pipelineMappings.at(this->_currentActiveStage);
 }

--- a/src/Graphics/Shader/ShaderStore.cpp
+++ b/src/Graphics/Shader/ShaderStore.cpp
@@ -1,8 +1,7 @@
-#include "DDE/Graphics/Shader/ShaderProgram.hpp"
-#include <Glad/glad/glad.h>
-
+#include <DDE/Graphics/Shader/ShaderProgram.hpp>
 #include <DDE/Graphics/Shader/ShaderStore.hpp>
 #include <DDE/Utility/ShaderTypes.hpp>
+#include <Glad/glad/glad.h>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/Graphics/Shader/ShaderStore.cpp
+++ b/src/Graphics/Shader/ShaderStore.cpp
@@ -73,7 +73,11 @@ DDE::ShaderStage DDE::ShaderStore::getActiveShaderStage() const {
   return this->_currentActiveStage;
 }
 
-// TODO: Documentation
+/**
+ * Retrive the ShaderProgram associated with the currently active ShaderStage
+ *
+ * @returns The currently active ShaderProgram in the ShaderEngine
+ */
 DDE::ShaderProgram DDE::ShaderStore::getActiveShaderProgram() const {
   return this->_pipelineMappings.at(this->_currentActiveStage);
 }

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -3,6 +3,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/DrawConfig)
 
 # Append the src files to SOURCES
 set(UTILITY_SOURCES 
-  ${CMAKE_CURRENT_SOURCE_DIR}/Image.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/Image.cpp
   ${DRAW_CONFIG_SOURCES}
   PARENT_SCOPE)

--- a/src/dde.cpp
+++ b/src/dde.cpp
@@ -40,10 +40,10 @@ void rotateQuad(DDE::Quad &quad) { quad.rotate(rotationDegrees, rotationAxis); }
 // Helper function for scaling a quad
 void scaleQuad(DDE::Quad &quad) {
   quad.scale(scale);
-  if (quad.getSize().x >= 2.0f) {
+  if (quad.getScale().x >= 2.0f) {
     scale.x = 0.99f;
     scale.y = 0.99f;
-  } else if (quad.getSize().x <= 0.5f) {
+  } else if (quad.getScale().x <= 0.5f) {
     scale.x = 1.01f;
     scale.y = 1.01f;
   }

--- a/src/dde.cpp
+++ b/src/dde.cpp
@@ -1,5 +1,6 @@
 #include <DDE/Graphics/Shape/Quad.hpp>
 #include <DDE/Utility/DrawConfig/DrawConfig.hpp>
+#include <DDE/Utility/PositionTypes.hpp>
 #include <Glad/glad/glad.h>
 #include <glm/fwd.hpp>
 
@@ -18,8 +19,6 @@
 // Base translation vector
 glm::vec3 translation(0.01f, 0.0f, 0.0f);
 
-// Vector representing our rotation axis
-glm::vec3 rotationAxis(0.0f, 0.0f, 1.0f);
 // Our degree of rotation per transformation
 const float rotationDegrees = 0.01f;
 
@@ -35,7 +34,9 @@ void translateQuad(DDE::Quad &quad) {
 }
 
 // Helper function for rotating a quad
-void rotateQuad(DDE::Quad &quad) { quad.rotate(rotationDegrees, rotationAxis); }
+void rotateQuad(DDE::Quad &quad) {
+  quad.rotate(rotationDegrees, DDE::Z_AXIS_VECTOR);
+}
 
 // Helper function for scaling a quad
 void scaleQuad(DDE::Quad &quad) {

--- a/src/dde.cpp
+++ b/src/dde.cpp
@@ -1,3 +1,4 @@
+#include "glm/fwd.hpp"
 #include <DDE/Graphics/Shape/Quad.hpp>
 #include <DDE/Utility/DrawConfig/DrawConfig.hpp>
 #include <Glad/glad/glad.h>
@@ -13,8 +14,9 @@
 #include <DDE/Utility/DrawConfig/TransparencyDrawConfig.hpp>
 #include <functional>
 
-void drawFunction(DDE::Pencil &pencil, DDE::Quad &triangle) {
-  pencil.draw(triangle);
+void drawFunction(DDE::Pencil &pencil, DDE::Quad &quad) {
+  pencil.draw(quad);
+  quad.rotate(1.0, glm::vec3(0.0, 0.0, 1.0));
 }
 
 int main() {
@@ -23,7 +25,6 @@ int main() {
   DDE::Quad quad{1.0f, 1.0f};
 
   DDE::Pencil pencil;
-  DDE::Triangle triangle(2.0f, 2.0f, DDE::Vec4{0.3f, 0.8f, 1.0f, 0.1f});
   engine.start(drawFunction, std::ref(pencil), std::ref(quad));
 
   return 0;

--- a/src/dde.cpp
+++ b/src/dde.cpp
@@ -1,7 +1,7 @@
-#include "glm/fwd.hpp"
 #include <DDE/Graphics/Shape/Quad.hpp>
 #include <DDE/Utility/DrawConfig/DrawConfig.hpp>
 #include <Glad/glad/glad.h>
+#include <glm/fwd.hpp>
 
 #include <DDE/Engine/RenderEngine.hpp>
 #include <DDE/Engine/ShaderEngine.hpp>
@@ -13,19 +13,87 @@
 #include <DDE/Graphics/Vertex/Vertex.hpp>
 #include <DDE/Utility/DrawConfig/TransparencyDrawConfig.hpp>
 #include <functional>
+#include <vector>
 
-void drawFunction(DDE::Pencil &pencil, DDE::Quad &quad) {
-  pencil.draw(quad);
-  quad.rotate(1.0, glm::vec3(0.0, 0.0, 1.0));
+// Base translation vector
+glm::vec3 translation(0.01f, 0.0f, 0.0f);
+
+// Vector representing our rotation axis
+glm::vec3 rotationAxis(0.0f, 0.0f, 1.0f);
+// Our degree of rotation per transformation
+const float rotationDegrees = 0.01f;
+
+// Base scale vector
+glm::vec3 scale(1.01f, 1.01f, 0.0f);
+
+// Helper function for translating a quad
+void translateQuad(DDE::Quad &quad) {
+  quad.translate(translation);
+  if (quad.getPosition().x >= 1.0f || quad.getPosition().x <= -1.0f) {
+    translation.x *= -1;
+  }
+}
+
+// Helper function for rotating a quad
+void rotateQuad(DDE::Quad &quad) { quad.rotate(rotationDegrees, rotationAxis); }
+
+// Helper function for scaling a quad
+void scaleQuad(DDE::Quad &quad) {
+  quad.scale(scale);
+  if (quad.getSize().x >= 2.0f) {
+    scale.x = 0.99f;
+    scale.y = 0.99f;
+  } else if (quad.getSize().x <= 0.5f) {
+    scale.x = 1.01f;
+    scale.y = 1.01f;
+  }
+}
+
+// Our render function
+void drawFunction(DDE::Pencil &pencil, std::vector<DDE::Quad> &quads) {
+
+  // Translate the first quad back and forth
+  translateQuad(quads[0]);
+
+  // Rotate the second quad on the Z-Axis
+  rotateQuad(quads[1]);
+
+  // Scale the third quad to double it's size then back down to half it's size
+  // over and over
+  scaleQuad(quads[2]);
+
+  // Draw each quad at the end of each transformation
+  for (DDE::Quad quad : quads) {
+    pencil.draw(quad);
+  }
+}
+
+// Helper function to generate our Quad shapes
+std::vector<DDE::Quad> getQuads() {
+
+  DDE::Quad quad1{0.25f, 0.25f};
+  quad1.translate(glm::vec3(0, 0.5f, 0));
+
+  DDE::Quad quad2{0.25f, 0.25f};
+
+  DDE::Quad quad3{0.25f, 0.25f};
+  quad3.translate(glm::vec3(0, -0.5f, 0));
+
+  return std::vector<DDE::Quad>{quad1, quad2, quad3};
 }
 
 int main() {
   // Create the Render Engine
   DDE::RenderEngine engine;
-  DDE::Quad quad{1.0f, 1.0f};
 
+  // Get our list of Quads
+  std::vector<DDE::Quad> quads = getQuads();
+
+  // Get our Pencil
   DDE::Pencil pencil;
-  engine.start(drawFunction, std::ref(pencil), std::ref(quad));
+
+  // Start the render loop with our render function
+  engine.start(drawFunction, std::ref(pencil), std::ref(quads));
 
   return 0;
 }

--- a/src/dde.cpp
+++ b/src/dde.cpp
@@ -13,19 +13,18 @@
 #include <DDE/Utility/DrawConfig/TransparencyDrawConfig.hpp>
 #include <functional>
 
-void drawFunction(DDE::Pencil &pencil, DDE::Triangle &triangle) {
-  pencil.draw<DDE::TransparencyDrawConfig>(triangle);
+void drawFunction(DDE::Pencil &pencil, DDE::Quad &triangle) {
+  pencil.draw(triangle);
 }
 
 int main() {
   // Create the Render Engine
   DDE::RenderEngine engine;
+  DDE::Quad quad{1.0f, 1.0f};
 
-  DDE::Triangle triangle(2.0f, 2.0f, DDE::Vec4{0.3f, 0.8f, 1.0f, 0.1f});
   DDE::Pencil pencil;
-
-  // Start the Rendering Enginge
-  engine.start(drawFunction, std::ref(pencil), std::ref(triangle));
+  DDE::Triangle triangle(2.0f, 2.0f, DDE::Vec4{0.3f, 0.8f, 1.0f, 0.1f});
+  engine.start(drawFunction, std::ref(pencil), std::ref(quad));
 
   return 0;
 }


### PR DESCRIPTION
We now have implemented the model matrix for the `Drawable` class. This now makes it possible for the user to translate, rotate, and scale drawable objects.

Note that the model matrix is only provided currently for the `Primitive` shader pipeline. DDE currently has no other pipelines, but when these are eventually developed we will have to integrate the model matrix into these as well.