### PR TITLE
[DDE-41] Remove Frustum From ShaderEngine

### DIFF
--- a/include/DDE/Engine/ShaderEngine.hpp
+++ b/include/DDE/Engine/ShaderEngine.hpp
@@ -20,13 +20,8 @@ private:
   // The static single shader store to be used in the lifetime of a DDE app.
   static DDE::ShaderStore _shaderStore;
 
-  // The static frustum attached to the Shader Engine
-  static DDE::Frustum _frustum;
-
 public:
   static void ActivateShaderStage(DDE::ShaderStage stage);
-  static void UpdateFrustum(DDE::Frustum frustum);
-
   static void UpdateModelMatrix(glm::mat4 matrix);
   static void UpdateProjectionMatrix(glm::mat4 matrix);
 

--- a/include/DDE/Graphics/Pencil/Pencil.hpp
+++ b/include/DDE/Graphics/Pencil/Pencil.hpp
@@ -48,6 +48,10 @@ public:
 
     // Update the Model Matrix to the drawable object's model matrix
     DDE::ShaderEngine::UpdateModelMatrix(drawableObject.getModelMatrix());
+    // Give the default projection matrix
+    DDE::ShaderEngine::UpdateProjectionMatrix(
+        DDE::Frustum().getProjectionMatrix());
+
     // Render the drawable object
     drawableObject.render();
 

--- a/src/Engine/ShaderEngine.cpp
+++ b/src/Engine/ShaderEngine.cpp
@@ -5,9 +5,6 @@
 // Define the static member variable shaderStore to a default DDE::ShaderStore
 DDE::ShaderStore DDE::ShaderEngine::_shaderStore;
 
-// Define the static member variable frustum to a default DDE::Frustum
-DDE::Frustum DDE::ShaderEngine::_frustum;
-
 /**
  * This function is what should be utilized to activate a specific
  * shader stage in other classes. It handles lazily loading the
@@ -18,8 +15,6 @@ DDE::Frustum DDE::ShaderEngine::_frustum;
 void DDE::ShaderEngine::ActivateShaderStage(DDE::ShaderStage stage) {
   if (ShaderEngine::_shaderStore.getActiveShaderStage() != stage) {
     glUseProgram(ShaderEngine::_shaderStore.loadShaderPipeline(stage));
-    DDE::ShaderEngine::UpdateProjectionMatrix(
-        ShaderEngine::_frustum.getProjectionMatrix());
   }
 }
 
@@ -57,17 +52,4 @@ void DDE::ShaderEngine::UpdateProjectionMatrix(glm::mat4 matrix) {
   // Set our 'dde_projection_matrix' uniform variable to the matrix passed
   activeProgram.setMatrix4x4Uniform(DDE::ShaderUniform::PROJECTION_MATRIX,
                                     matrix);
-}
-
-/**
- * This function is used to update the attached Frustum to the
- * ShaderEngine. The ShaderEngine frustum is used to evaluate
- * the projection matrix everytime ActivateShaderStage is called.
- * The ShaderEngine starts with a default 200x200x100 orthographic
- * frustum.
- *
- * @param frustum The frustum object we are attaching to the ShaderEngine
- */
-void DDE::ShaderEngine::UpdateFrustum(DDE::Frustum frustum) {
-  DDE::ShaderEngine::_frustum = frustum;
 }


### PR DESCRIPTION
This PR is intended to remove the Frustum out of the ShaderEngine. We are currently just setting the Projection Matrix in the Pencil which really makes no sense, but hopefully we can clean these things up in a future PR.

https://server-duels.atlassian.net/browse/DDE-41